### PR TITLE
Remove the license mentioned in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ Typically, a Python IDE (Integrated Development Environment) allows you add a "s
 Note that xbmcstubs are literally stubs and do not include any useful code, so please don't try to run your program outside Kodi unless you add some testing code into xbmcstubs.
 
 Auto-generated XBMC Python API documentation from xbmcstubs docstrings: http://romanvm.github.io/xbmcstubs/docs
-
-License: GPL v.3 http://www.gnu.org/licenses/gpl.html


### PR DESCRIPTION
Since you didn't make this project from scratch and doesn't own the copyright to the code, you are not entitled to put the code under any license, unless you get consent from the authors of the code you want to license. As such you should remove the license mentioned in the README file.